### PR TITLE
Check for ImplicitlyUnwrappedOptional in valueForAny(...)

### DIFF
--- a/EVReflection/EVReflectionTests/EVReflectionTests.swift
+++ b/EVReflection/EVReflectionTests/EVReflectionTests.swift
@@ -391,6 +391,38 @@ class EVReflectionTests: XCTestCase {
         let newJson = object.toJsonString()
         print("back to json = \(newJson)\n\n\(object)")
     }
+  
+    func testImplicitlyUnwrappedOptionalProperty() {
+        let nested = NSDictionary(dictionary: ["property1": 10, "property2": 20])
+        print(String(describing: nested))
+        let parentWithChild = NSDictionary(dictionary: ["iuoObject": nested, "control": "testVal"])
+        print(String(describing: parentWithChild))
+        
+        let a: NestedIUOObject = NestedIUOObject(dictionary: nested)
+        XCTAssertEqual(a.property1, 10)
+        XCTAssertEqual(a.property2, 20)
+        
+        let b = NestedIUOObjectParent(dictionary: parentWithChild)
+        XCTAssertNotNil(b.iuoObject)
+        XCTAssertEqual(b.iuoObject.property1, 10)
+        XCTAssertEqual(b.iuoObject.property2, 20)
+        XCTAssertEqual(b.control, "testVal")
+        
+        let parentNoChild = NSDictionary(dictionary: ["control": "testVal"])
+        print(String(describing: parentWithChild))
+        let c = NestedIUOObjectParent(dictionary: parentNoChild)
+        XCTAssertNil(c.iuoObject)
+        XCTAssertEqual(c.control, "testVal")
+        
+        let parentWithChildren = NSDictionary(dictionary: ["iuoObjects": [nested, nested], "control": "testVal"])
+        let d: NestedIUOObjectsArrayParent = NestedIUOObjectsArrayParent(dictionary: parentWithChildren)
+        XCTAssertNotNil(d.iuoObjects)
+        XCTAssertEqual(d.iuoObjects.count, 2)
+        let child1 = d.iuoObjects[0]
+        XCTAssertEqual(child1.property1, 10)
+        XCTAssertEqual(child1.property2, 20)
+        XCTAssertEqual(d.control, "testVal")
+    }
 }
 
 

--- a/EVReflection/EVReflectionTests/TestObjects.swift
+++ b/EVReflection/EVReflectionTests/TestObjects.swift
@@ -261,3 +261,18 @@ class ImLazy: EVObject {
     lazy var lazyInt: Int = 0
     lazy var LazyString: String = ""
 }
+
+open class NestedIUOObject: EVObject {
+    var property1: Int = 0
+    var property2: Int = 0
+}
+
+open class NestedIUOObjectParent: EVObject {
+    var iuoObject: NestedIUOObject!
+    var control: String?
+}
+
+open class NestedIUOObjectsArrayParent: EVObject {
+    var iuoObjects: [NestedIUOObject]!
+    var control: String?
+}

--- a/EVReflection/pod/EVReflection.swift
+++ b/EVReflection/pod/EVReflection.swift
@@ -651,6 +651,11 @@ final public class EVReflection {
                 let (enumValue, enumType, _) = valueForAny(theValue, key: value.associated.label, anyValue: value.associated.value as Any, conversionOptions: conversionOptions, isCachable: isCachable, parents: parents)
                 valueType = enumType
                 theValue = enumValue
+            } else if valueType.hasPrefix("Swift.ImplicitlyUnwrappedOptional<") { // Implicitly Unwrapped Optionals are actually fancy enums
+                var subtype: String = valueType.substring(from: (valueType.components(separatedBy: "<") [0] + "<").endIndex)
+                subtype = subtype.substring(to: subtype.characters.index(before: subtype.endIndex))
+                valueType = convertToInternalSwiftRepresentation(type: subtype)
+                return (NSNull(), valueType, false)
             } else {
                 theValue = "\(theValue)"
             }


### PR DESCRIPTION
ImplicitlyUnwrappedOptional is an enum type and previously was not
checked for in the .enum case of valueForAny(). This caused the
`theValue` variable to be set as nil.